### PR TITLE
fix issue of localstorage settings sticking between different reports

### DIFF
--- a/examples/wbs.rails-commerce.md
+++ b/examples/wbs.rails-commerce.md
@@ -14,6 +14,9 @@ toggle {#stories-toggle}
 
 totals {#stories-total}
 
+***NOTE:*** By default the filter only shows "New" estimated work. Change the
+filter setting to see the full project layout.
+
 filter {#display-filter}
 
 style {#display-style}

--- a/lib/report/components/detail-level/detail-level.vue
+++ b/lib/report/components/detail-level/detail-level.vue
@@ -4,7 +4,8 @@
       <button v-for="level in maxlevel" type="button"
           class="btn btn-default"
           v-bind:class="{ active: level == activeLevel }"
-          @click.stop="levelSelected(level)">
+          @click.stop="levelSelected(level)"
+          :title="buttonTitle(level)">
         {{ level }}
       </button>
     </div>
@@ -28,6 +29,9 @@
       levelSelected: function(newLevel) {
         this.activeLevel = newLevel
         this.$emit("change", newLevel)
+      },
+      buttonTitle: function(level) {
+        return "Set level of detail to " + level
       }
     }
   };

--- a/lib/report/components/vue-main/vue-main.js
+++ b/lib/report/components/vue-main/vue-main.js
@@ -20,9 +20,18 @@ new Vue({
     selected_level: 0
   },
   mounted: function() {
+    this.can_use_local_storage = testLocalStorageAccess('lastDocId')
+    // Load lastDocId from localstorage. If something was loaded (failure to
+    // read returns a null). If found a previous ID and it is different from
+    // this report's document.
+    var lastDocId = safeGetLocalStorageItem("lastDocId", null)
+    if (lastDocId && reportConfig.document_id && lastDocId != reportConfig.document_id) {
+      deleteLocalStorageKeys(["stories", "selected_level", "filter_mode"])
+    }
+    this.saveToLocalStorage('lastDocId', reportConfig.document_id)
+
     // get a list of stories
     var totalStories = _.map(this.stories, 'story')
-    this.can_use_local_storage = testLocalStorageAccess('filter_mode')
 
     // load the persisted localStorage settings and try to apply them now.
     //
@@ -173,7 +182,7 @@ new Vue({
         localStorage.setItem(key, value)
       }
       else {
-        console.warn("Unable to write " + key + " to local storage.")
+        console.warn("Unable to write " + key + " to local storage. Value:", value)
       }
     }
   }
@@ -295,6 +304,20 @@ function safeGetLocalStorageItem(key, fallback) {
     console.error("Blocked from using localStorage")
     console.log("returning fallback", fallback)
     return fallback
+  }
+}
+
+/**
+ * Delete the specified keys from localstorage.
+ * @param {Array} keys  Array of key names to delete
+ */
+function deleteLocalStorageKeys(keys) {
+  try {
+    _.forEach(keys, function(key) {
+      localStorage.removeItem(key)
+    });
+  } catch (e) {
+    console.error("Blocked from using localStorage")
   }
 }
 

--- a/lib/report/generate.js
+++ b/lib/report/generate.js
@@ -13,6 +13,7 @@
 var path = require('path');
 var chokidar = require('chokidar');
 var _ = require('lodash');
+var md5 = require('md5')
 var version = require("../version").version;
 var fileUtils = require("../file-utils");
 var settings = require("../settings");
@@ -30,6 +31,17 @@ function applyConfigDefaults(config) {
   }
   var defaultConfig = JSON.parse(fileUtils.read(path.join(__dirname, '../config/default.json')));
   _.mergeWith(config, defaultConfig, customizer);
+}
+
+/**
+ * Given a config object, apply a computed MD5 hash as a "document_id" so it
+ * will be accessible to the report at runtime.
+ * This function modifies the passed config object.
+ * @param {Object} config  The user-supplied .wbsm-config.json file
+ * @param {String} md5Hash  Computed MD5 hash of the full project filename
+ */
+function applyMd5HashToConfigDefaults(config, md5Hash) {
+  _.mergeWith(config, {document_id: md5Hash})
 }
 
 /**
@@ -112,20 +124,22 @@ function compileHtml(template, config, data) {
 
 // Read the contents of a file out synchronously and return the file contents.
 function generate(markdownFilename, reportFilename) {
-  // console.log("--------------------md file: ", markdownFilename)
   // read markdown file contents
   var mdContents = fileUtils.read(markdownFilename);
-  // console.log("--------------------contents", mdContents)
-
   if (typeof mdContents === 'undefined') {
     console.error('No markdown contents found!');
     process.exit(1);
   }
 
+  // get the full path of the filename. Use to generate an MD5 hash to ID this
+  // file. Used for detecting when localstorage settings don't apply.
+  var md5Filename = md5(path.join(__dirname, markdownFilename))
+
   var renderTemplateFilename = settings.getTemplateFilename()
   var dateText = new Date().toLocaleString()
   var config = JSON.parse(fileUtils.read("./.wbsm-config.json"));
   applyConfigDefaults(config);
+  applyMd5HashToConfigDefaults(config, md5Filename)
   var content = mdToHtml(mdContents, config);
   var assets = getAssets(config);
   var template = fileUtils.read(renderTemplateFilename);

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lodash": "^4.17.10",
     "markdown-it": "^8.4.0",
     "markdown-it-attrs": "^1.1.0",
-    "markdown-it-source-map": "^0.1.1"
+    "markdown-it-source-map": "^0.1.1",
+    "md5": "^2.2.1"
   }
 }


### PR DESCRIPTION
- generate an MD5 hash based on the full filename of the report
- write that document_id to localStorage
- when the document ID for the current report is different from the last
viewed one, clear certain localStorage values

closes #13 